### PR TITLE
removes 'ecoli/' from link urls

### DIFF
--- a/ecoli/prototype.html
+++ b/ecoli/prototype.html
@@ -3,10 +3,10 @@
   <link rel="stylesheet" href="stylee/main.css">
   <header>
     <nav class="container">
-      <div class="navbar"><a href="ecoli/home.html">Home</a></div>
-      <div class="navbar"><a href="ecoli/ecoliinfo.html">Background</a></div>
-        <div class="navbar"><a href="ecoli/prototype.html">Prototype</a></div>
-          <div class="navbar"><a href="ecoli/contact.html">Contact</a></div>
+      <div class="navbar"><a href="home.html">Home</a></div>
+      <div class="navbar"><a href="ecoliinfo.html">Background</a></div>
+        <div class="navbar"><a href="prototype.html">Prototype</a></div>
+          <div class="navbar"><a href="contact.html">Contact</a></div>
 </nav>
 <div class="pics">
 <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReAK3Up8ly2kSFdZXkV71ZZGwsDpn7A84cwbuHNRC0oju1Jmyt6A">


### PR DESCRIPTION
If this works on this page, you can implement the same change on the others :)